### PR TITLE
feat: 모의 면접 실행 및 재실행 로직 수정

### DIFF
--- a/devpath/src/main/java/com/freepath/devpath/interview/command/application/dto/response/InterviewRoomCommandResponse.java
+++ b/devpath/src/main/java/com/freepath/devpath/interview/command/application/dto/response/InterviewRoomCommandResponse.java
@@ -2,6 +2,8 @@ package com.freepath.devpath.interview.command.application.dto.response;
 
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @Builder
 public class InterviewRoomCommandResponse {
@@ -12,4 +14,5 @@ public class InterviewRoomCommandResponse {
     private String evaluationStrictness;
     private String interviewRoomMemo;
     private String firstQuestion;
+    private List<String> questions;
 }

--- a/devpath/src/main/java/com/freepath/devpath/interview/command/application/service/InterviewCommandService.java
+++ b/devpath/src/main/java/com/freepath/devpath/interview/command/application/service/InterviewCommandService.java
@@ -151,13 +151,16 @@ public class InterviewCommandService {
         String nextQuestion = null;
         DifficultyLevel difficultyLevel = Optional.ofNullable(room.getDifficultyLevel())
                 .orElse(DifficultyLevel.MEDIUM);
+
         if (interviewIndex < 3) {
             if (room.getParentInterviewRoomId() != null) {
-                // 재실행 면접방인 경우, 기존 질문 복사본을 순서대로 사용한다
-                List<Interview> copiedQuestions = interviewRepository.findByInterviewRoomIdAndInterviewRoleOrderByInterviewIdAsc(roomId, InterviewRole.AI);
-                nextQuestion = copiedQuestions.get(interviewIndex).getInterviewMessage(); // index 1이면 두 번째 질문
+                //  재실행 : 복제된 질문만 꺼내오기 (다시 저장하면 중복이므로 save() 호출 X)
+                List<Interview> copiedQuestions = interviewRepository
+                        .findByInterviewRoomIdAndInterviewRoleOrderByInterviewIdAsc(roomId, InterviewRole.AI);
+                nextQuestion = copiedQuestions.get(interviewIndex).getInterviewMessage();
+
             } else {
-                // 재실행 면접방이 아니라 새로운 면접방인 경우
+                // 새 면접
                 List<String> previousQuestions = interviewRepository.findByInterviewRoomId(roomId).stream()
                         .filter(i -> i.getInterviewRole() == InterviewRole.AI)
                         .map(Interview::getInterviewMessage)
@@ -168,15 +171,16 @@ public class InterviewCommandService {
                         room.getInterviewCategory(), difficultyLevel,
                         previousQuestions
                 );
-            }
 
-            interviewRepository.save(
-                    Interview.builder()
-                            .interviewRoomId(roomId)
-                            .interviewRole(InterviewRole.AI)
-                            .interviewMessage(nextQuestion)
-                            .build()
-            );
+                // 새 면접 모드일 때만 저장
+                interviewRepository.save(
+                        Interview.builder()
+                                .interviewRoomId(roomId)
+                                .interviewRole(InterviewRole.AI)
+                                .interviewMessage(nextQuestion)
+                                .build()
+                );
+            }
         }
 
         // 5. 평균 점수 계산
@@ -256,7 +260,7 @@ public class InterviewCommandService {
                 .filter(i -> i.getInterviewMessage() != null && i.getInterviewMessage().startsWith("[면접 질문]"))
                 .toList();
 
-        if (originalQuestions.size() != 3) {
+        if (originalQuestions.size() < 3) {
             throw new InterviewQuestionCreationException(ErrorCode.INTERVIEW_QUESTION_CREATION_FAILED);
         }
 
@@ -277,8 +281,9 @@ public class InterviewCommandService {
         );
 
         // 3. 새 방 ID로 3개 질문 저장
+        List<Interview> toCopy = originalQuestions.subList(0, 3);
         List<String> questionMessages = new ArrayList<>();
-        for (Interview q : originalQuestions) {
+        for (Interview q : toCopy) {
             String msg = q.getInterviewMessage();
             questionMessages.add(msg);
             interviewRepository.save(Interview.builder()

--- a/devpath/src/main/java/com/freepath/devpath/interview/command/application/service/InterviewCommandService.java
+++ b/devpath/src/main/java/com/freepath/devpath/interview/command/application/service/InterviewCommandService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -275,14 +276,16 @@ public class InterviewCommandService {
                         .build()
         );
 
-        // 5. 복제된 질문 저장
-        for (Interview question : originalQuestions) {
-            interviewRepository.save(
-                    Interview.builder()
-                            .interviewRoomId(newRoom.getInterviewRoomId())
-                            .interviewRole(InterviewRole.AI)
-                            .interviewMessage(question.getInterviewMessage())
-                            .build()
+        // 3. 새 방 ID로 3개 질문 저장
+        List<String> questionMessages = new ArrayList<>();
+        for (Interview q : originalQuestions) {
+            String msg = q.getInterviewMessage();
+            questionMessages.add(msg);
+            interviewRepository.save(Interview.builder()
+                    .interviewRoomId(newRoom.getInterviewRoomId())
+                    .interviewRole(InterviewRole.AI)
+                    .interviewMessage(msg)
+                    .build()
             );
         }
 
@@ -290,10 +293,9 @@ public class InterviewCommandService {
         return InterviewRoomCommandResponse.builder()
                 .interviewRoomId(newRoom.getInterviewRoomId())
                 .interviewRoomTitle(newRoom.getInterviewRoomTitle())
-                .interviewRoomStatus(newRoom.getInterviewRoomStatus().name())
                 .difficultyLevel(newRoom.getDifficultyLevel().name())
                 .evaluationStrictness(newRoom.getEvaluationStrictness().name())
-                .firstQuestion(originalQuestions.get(0).getInterviewMessage())
+                .questions(questionMessages)
                 .build();
     }
 


### PR DESCRIPTION
## 🔥 작업 내용  
- [x] 재실행 시 질문 저장 안하도록 로직 수정
- [x] 면접방 상세 조회 시 답변 보여지는 로직 수정

## ✅ 체크 리스트  
- [x] 기능 정상 동작 확인